### PR TITLE
add maintech to frontmatter & display in ProjectSnippet

### DIFF
--- a/src/components/ProjectSnippet.jsx
+++ b/src/components/ProjectSnippet.jsx
@@ -11,6 +11,7 @@ const ProjectSnippet = ({
   blurb,
   imageFluid,
   slug,
+  maintech,
 }) => {
   const variants = {
     show: i => ({
@@ -31,7 +32,7 @@ const ProjectSnippet = ({
 
   return (
     <TransitionLinkDefault
-      className='relative block mb-6 lg:text-gray-600 text-gray-900 hover:text-gray-900 transition-color'
+      className='relative block mb-8 lg:text-gray-600 text-gray-900 hover:text-gray-900 transition-color'
       to={slug}
       onMouseEnter={() => {
         setActiveImage(imageIndex)
@@ -43,9 +44,16 @@ const ProjectSnippet = ({
         animate='show'
         custom={imageIndex}
       >
-        <h2 className='font-bold underline text-xl lg:mb-0 mb-4'>{title}</h2>
+        <h2 className='underline text-2xl'>{title}</h2>
+        <div className='lg:mb-0 font-bold mb-4 mt-2'>
+          {maintech.split(',').map((item, i) => (
+            <span>
+              {i !== 0 ? ' |' : ''} {item}
+            </span>
+          ))}
+        </div>
         <Img className='lg:hidden shadow-lg' fluid={imageFluid} />
-        <p className='lg:mt-1 mt-6 sm:text-base text-sm'>{blurb}</p>
+        <p className='lg:mt-2 mt-6 sm:text-base text-sm'>{blurb}</p>
       </motion.div>
     </TransitionLinkDefault>
   )

--- a/src/data/livestream-radio.md
+++ b/src/data/livestream-radio.md
@@ -2,6 +2,7 @@
 title: "Livestream Radio"
 blurb: "A website for categorizing YouTube livestreams. Written primarily in Vue."
 image: ../images/livestream-radio.png
+maintech: Vue,Vuetify,SCSS
 tags: Vue,Vuetify,SCSS,GitHub,Material Design,YouTube iframe API
 ---
 A [website](https://livestreamradio.netlify.com/) that allows a user to add & categorize YouTube livestreams as “stations”. Open source and maintained on [GitHub](https://github.com/sparlos/livestream-radio).

--- a/src/data/sparling-creations.md
+++ b/src/data/sparling-creations.md
@@ -2,6 +2,7 @@
 title: "Sparling Creations"
 blurb: "Freelance business site showcasing web design, video editing and music production talents. Written primarily in Vue."
 image: ../images/sparling-creations.png
+maintech: Vue,SCSS,GitHub
 tags: Vue,Vue Router,SCSS,GitHub,SoundCloud API  
 ---
 

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -50,13 +50,14 @@ const Projects = ({ data }) => {
   const projects = () =>
     data.allMarkdownRemark.edges.map(({ node }, i) => {
       const id = node.id
-      const { title, blurb, image } = node.frontmatter
+      const { title, blurb, image, maintech } = node.frontmatter
       const slug = node.fields.slug
 
       const imageFluid = image.childImageSharp.fluid
 
       return (
         <ProjectSnippet
+          maintech={maintech}
           slug={slug}
           key={id}
           imageIndex={i}
@@ -114,6 +115,7 @@ export const query = graphql`
           frontmatter {
             title
             blurb
+            maintech
             image {
               childImageSharp {
                 fluid(maxWidth: 1000) {


### PR DESCRIPTION
Add a list of main technologies I use on each project for display in the ProjectSnippet component. Essential UX for recruiters to know what each project is built on so they are able to streamline their traversal through the Projects section.